### PR TITLE
Add domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ global namespace).
    [AWS](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials))
 
 1. Run `takeonme <service name> <resource name>` to print API output a
-   given resource from service name (e.g. `takeonme aws dns` for
-   Route53 DNS records) as JSON
+   given resource from service name (e.g. `takeonme aws domains` for
+   Route53 DNS records)
 
 1. Run a tool to detect whether any of the resources can be hijacked
    (e.g. [subjack](https://github.com/haccer/subjack) for subdomains)

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ Requirements:
 ## Implemented resources
 
 * [AWS Route53 DNS records](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecord.html)
-* [GCP DNS]()
+* [GCP Cloud DNS records](https://cloud.google.com/dns/docs/reference/v1/resourceRecordSets#resource)

--- a/takeonme/aws/commands.py
+++ b/takeonme/aws/commands.py
@@ -15,7 +15,7 @@ def cli(ctx: click.Context) -> None:
     pass
 
 
-@cli.command("dns")
+@cli.command("domains")
 @click.pass_context
 def dns(ctx: click.Context) -> None:
     """Fetch and write AWS DNS records to the output file

--- a/takeonme/aws/commands.py
+++ b/takeonme/aws/commands.py
@@ -1,4 +1,4 @@
-import json
+from json import dump as dump_json
 
 import click
 
@@ -16,12 +16,24 @@ def cli(ctx: click.Context) -> None:
 
 
 @cli.command("domains")
+@click.option("--json", default=False, is_flag=True)
 @click.pass_context
-def dns(ctx: click.Context) -> None:
-    """Fetch and write AWS DNS records to the output file
+def domains(ctx: click.Context, json: bool) -> None:
+    """Fetch, buffer, and write AWS DNS records to the output file
 
-    Buffers records in memory then pretty prints them to the output
-    file as JSON with sorted keys
+    Sort, de-dupe, and print one unique domain name per line
+    or when --json is provided pretty print JSON with sorted keys
 
     """
-    json.dump(r53.get_all_records(), ctx.obj["output"], sort_keys=True, indent=4)
+    output = ctx.obj["output"]
+    records = r53.get_all_records()
+    if json:
+        dump_json(records, output, sort_keys=True, indent=4)
+    else:
+        record_names = [
+            record.get("Name", None)
+            for record in records
+            if record and record.get("Name", None)
+        ]
+        for unique_domain in sorted(set(record_names)):
+            output.write(f"{unique_domain}\n")

--- a/takeonme/aws/route53.py
+++ b/takeonme/aws/route53.py
@@ -30,6 +30,11 @@ def fetch_records_for_hosted_zone(
 
 
 def get_all_records() -> List[Dict[str, Any]]:
+    """
+    Return Route53 DNS resource record sets
+
+    https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html
+    """
     client = get_client()
     return [
         record

--- a/takeonme/aws/route53.py
+++ b/takeonme/aws/route53.py
@@ -13,20 +13,20 @@ def get_client() -> boto3.session.Session.client:
 def fetch_hosted_zones(
     client: boto3.session.Session.client,
 ) -> Generator[Dict[str, Any], None, None]:
-    for zone in client.get_paginator("list_hosted_zones").paginate():
-        assert "HostedZones" in zone
-        yield zone["HostedZones"]
+    for zones in client.get_paginator("list_hosted_zones").paginate():
+        assert "HostedZones" in zones
+        yield from zones["HostedZones"]
 
 
 def fetch_records_for_hosted_zone(
     client: boto3.session.Session.client, hosted_zone: Dict[str, Any]
 ) -> Generator[Dict[str, Any], None, None]:
     assert "Id" in hosted_zone
-    for record_set in client.get_paginator("list_resource_record_sets").paginate(
+    for record_sets in client.get_paginator("list_resource_record_sets").paginate(
         HostedZoneId=hosted_zone["Id"]
     ):
-        assert "ResourceRecordSets" in record_set
-        yield record_set["ResourceRecordSets"]
+        assert "ResourceRecordSets" in record_sets
+        yield from record_sets["ResourceRecordSets"]
 
 
 def get_all_records() -> List[Dict[str, Any]]:

--- a/takeonme/cli.py
+++ b/takeonme/cli.py
@@ -5,7 +5,7 @@ import takeonme.gcp.commands
 
 
 @click.group()
-@click.option("-o", "--output", type=click.File("wb"), default="-")
+@click.option("-o", "--output", type=click.File("w"), default="-")
 @click.pass_context
 def cli(ctx: click.Context, output: click.File) -> None:
     ctx.ensure_object(dict)

--- a/takeonme/gcp/commands.py
+++ b/takeonme/gcp/commands.py
@@ -12,9 +12,9 @@ def cli(ctx: click.Context) -> None:
     pass
 
 
-@cli.command("dns")
+@cli.command("domains")
 @click.pass_context
-def dns(ctx: click.Context) -> None:
+def domains(ctx: click.Context) -> None:
     """Fetch and write GCP DNS records to the output file
 
     Buffers records in memory then pretty prints them to the output

--- a/takeonme/gcp/commands.py
+++ b/takeonme/gcp/commands.py
@@ -1,4 +1,4 @@
-import json
+from json import dump as dump_json
 
 import click
 
@@ -13,17 +13,29 @@ def cli(ctx: click.Context) -> None:
 
 
 @cli.command("domains")
+@click.option("--json", default=False, is_flag=True)
 @click.pass_context
-def domains(ctx: click.Context) -> None:
-    """Fetch and write GCP DNS records to the output file
+def domains(ctx: click.Context, json: bool) -> None:
+    """Fetch, buffer, and write GCP DNS records to the output file
 
-    Buffers records in memory then pretty prints them to the output
-    file as JSON with sorted keys
+    Sort, de-dupe, and print one unique domain name per line
+    or when --json is provided pretty print JSON with sorted keys
 
     """
-    json.dump(
-        cloud_dns.get_all_records(),
-        ctx.obj["output"],
-        sort_keys=True,
-        indent=4,
-    )
+    output = ctx.obj["output"]
+    records = cloud_dns.get_all_records()
+    if json:
+        dump_json(
+            records,
+            output,
+            sort_keys=True,
+            indent=4,
+        )
+    else:
+        record_names = [
+            record.get("name", None)
+            for record in records
+            if record and record.get("name", None)
+        ]
+        for unique_domain in sorted(set(record_names)):
+            output.write(f"{unique_domain}\n")


### PR DESCRIPTION
Changes:

* **breaking** rename AWS and GCP `dns` subcommand to `domains`
* **breaking** change the default output file mode to text from binary 
* move JSON output behind a `--json` flag
* default to printing a unique list of domains to the output file
* fix AWS Route53 listing 